### PR TITLE
Modify generate_polygons.sh for fewer runs

### DIFF
--- a/generate_polygons.sh
+++ b/generate_polygons.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-for (( i=0; i<101; i++ )) ; do
+for (( i=0; i<101; i+=5 )) ; do
   yaml_dir="./export/${i}"
   mkdir -p $yaml_dir
-  python3 generate_synthetic_data.py -ns 100 -no ${i} -d ./data/ -y $yaml_dir
+  python3 generate_synthetic_data.py -ns 100 -no ${i} -d ./data/ -y $yaml_dir --hull_size 3000 3000 --no_overlaps
 done


### PR DESCRIPTION
 - Generate increments of 5 obstacles
 - Hull size 3000 x 3000
 - Include no-overlaps (looks nicer, makes more sense since some obstacles could be fully contained in others, muddying our obstacle counts a bit)